### PR TITLE
Alert View Message Alignment

### DIFF
--- a/Example/URBNAlert/URBNViewController.m
+++ b/Example/URBNAlert/URBNViewController.m
@@ -46,6 +46,7 @@
 - (IBAction)activeAlertTouch:(id)sender {
     URBNAlertViewController *uac = [[URBNAlertViewController alloc] initWithTitle:@"The Title of my message can be up to 2 lines long. It wraps and centers." message:@"And the message that is a bunch of text. And the message that is a bunch of text. And the message that is a bunch of text.  "];
     uac.alertStyler.blurTintColor = [[UIColor orangeColor] colorWithAlphaComponent:0.4];
+    uac.alertStyler.alignment = NSTextAlignmentCenter;
     [uac addAction:[URBNAlertAction actionWithTitle:@"Done" actionType:URBNAlertActionTypeNormal actionCompleted:^(URBNAlertAction *action) {
           // Do something
     }]];
@@ -65,7 +66,7 @@
     [uac addAction:[URBNAlertAction actionWithTitle:@"Button Two" actionType:URBNAlertActionTypeDestructive actionCompleted:^(URBNAlertAction *action) {
           // Do something
     }]];
-    
+    uac.alertStyler.alignment = NSTextAlignmentCenter;
     [uac show];
 }
 
@@ -89,7 +90,7 @@
     uac.alertStyler.alertShadowOffset = CGSizeMake(6, 6);
     uac.alertStyler.alertViewShadowColor = [UIColor greenColor];
     uac.alertStyler.blurTintColor = [[UIColor blackColor] colorWithAlphaComponent:0.4];
-    
+    uac.alertStyler.alignment = NSTextAlignmentCenter;
     [uac addAction:[URBNAlertAction actionWithTitle:@"Destructive" actionType:URBNAlertActionTypeDestructive actionCompleted:^(URBNAlertAction *action) {
         // Do something
     }]];

--- a/Example/URBNAlert/URBNViewController.m
+++ b/Example/URBNAlert/URBNViewController.m
@@ -46,7 +46,7 @@
 - (IBAction)activeAlertTouch:(id)sender {
     URBNAlertViewController *uac = [[URBNAlertViewController alloc] initWithTitle:@"The Title of my message can be up to 2 lines long. It wraps and centers." message:@"And the message that is a bunch of text. And the message that is a bunch of text. And the message that is a bunch of text.  "];
     uac.alertStyler.blurTintColor = [[UIColor orangeColor] colorWithAlphaComponent:0.4];
-    uac.alertStyler.alignment = NSTextAlignmentCenter;
+    uac.alertStyler.messageAlignment = NSTextAlignmentCenter;
     [uac addAction:[URBNAlertAction actionWithTitle:@"Done" actionType:URBNAlertActionTypeNormal actionCompleted:^(URBNAlertAction *action) {
           // Do something
     }]];
@@ -66,7 +66,7 @@
     [uac addAction:[URBNAlertAction actionWithTitle:@"Button Two" actionType:URBNAlertActionTypeDestructive actionCompleted:^(URBNAlertAction *action) {
           // Do something
     }]];
-    uac.alertStyler.alignment = NSTextAlignmentCenter;
+    
     [uac show];
 }
 
@@ -90,7 +90,7 @@
     uac.alertStyler.alertShadowOffset = CGSizeMake(6, 6);
     uac.alertStyler.alertViewShadowColor = [UIColor greenColor];
     uac.alertStyler.blurTintColor = [[UIColor blackColor] colorWithAlphaComponent:0.4];
-    uac.alertStyler.alignment = NSTextAlignmentCenter;
+    uac.alertStyler.messageAlignment = NSTextAlignmentRight;
     [uac addAction:[URBNAlertAction actionWithTitle:@"Destructive" actionType:URBNAlertActionTypeDestructive actionCompleted:^(URBNAlertAction *action) {
         // Do something
     }]];

--- a/Pod/Classes/URBNAlertStyle.h
+++ b/Pod/Classes/URBNAlertStyle.h
@@ -51,6 +51,11 @@
 @property (nonatomic, strong) UIFont *titleFont;
 
 /**
+ * Alignment of the titles's message
+ */
+@property (nonatomic, assign) NSTextAlignment titleAlignment;
+
+/**
  * Font of the alert's message
  */
 @property (nonatomic, strong) UIFont *messageFont;

--- a/Pod/Classes/URBNAlertStyle.h
+++ b/Pod/Classes/URBNAlertStyle.h
@@ -58,7 +58,7 @@
 /**
  * Alignment of the alert's message
  */
-@property (nonatomic, assign) NSTextAlignment alignment;
+@property (nonatomic, assign) NSTextAlignment messageAlignment;
 
 /**
  * Font of the button's titles

--- a/Pod/Classes/URBNAlertStyle.h
+++ b/Pod/Classes/URBNAlertStyle.h
@@ -56,6 +56,11 @@
 @property (nonatomic, strong) UIFont *messageFont;
 
 /**
+ * Alignment of the alert's message
+ */
+@property (nonatomic, assign) NSTextAlignment alignment;
+
+/**
  * Font of the button's titles
  */
 @property (nonatomic, strong) UIFont *buttonFont;

--- a/Pod/Classes/URBNAlertStyle.m
+++ b/Pod/Classes/URBNAlertStyle.m
@@ -19,6 +19,10 @@
     return _titleFont ?: [UIFont boldSystemFontOfSize:14];
 }
 
+- (NSTextAlignment)titleAlignment {
+    return _titleAlignment ?: NSTextAlignmentCenter;
+}
+
 #pragma mark - Message
 - (UIColor *)messageColor {
     return _messageColor ?: [UIColor blackColor];
@@ -162,6 +166,7 @@
     styler.buttonFont = self.buttonFont.copy;
     
     // NSTextAlignment
+    styler.titleAlignment = self.titleAlignment;
     styler.messageAlignment = self.messageAlignment;
     
     // NSNumbers

--- a/Pod/Classes/URBNAlertStyle.m
+++ b/Pod/Classes/URBNAlertStyle.m
@@ -28,8 +28,8 @@
     return _messageFont ?: [UIFont systemFontOfSize:14];
 }
 
-- (NSTextAlignment)alignment {
-    return _alignment ?: NSTextAlignmentLeft;
+- (NSTextAlignment)messageAlignment {
+    return _messageAlignment ?: NSTextAlignmentLeft;
 }
 
 #pragma mark - Error
@@ -162,7 +162,7 @@
     styler.buttonFont = self.buttonFont.copy;
     
     // NSTextAlignment
-    styler.alignment = self.alignment;
+    styler.messageAlignment = self.messageAlignment;
     
     // NSNumbers
     styler.buttonCornerRadius = self.alertCornerRadius.copy;

--- a/Pod/Classes/URBNAlertStyle.m
+++ b/Pod/Classes/URBNAlertStyle.m
@@ -28,6 +28,10 @@
     return _messageFont ?: [UIFont systemFontOfSize:14];
 }
 
+- (NSTextAlignment)alignment {
+    return _alignment ?: NSTextAlignmentLeft;
+}
+
 #pragma mark - Error
 - (UIColor *)errorTextColor {
     return _errorTextColor ?: [UIColor redColor];
@@ -156,6 +160,9 @@
     styler.titleFont = self.titleFont.copy;
     styler.messageFont = self.messageFont.copy;
     styler.buttonFont = self.buttonFont.copy;
+    
+    // NSTextAlignment
+    styler.alignment = self.alignment;
     
     // NSNumbers
     styler.buttonCornerRadius = self.alertCornerRadius.copy;

--- a/Pod/Classes/URBNAlertView.m
+++ b/Pod/Classes/URBNAlertView.m
@@ -171,6 +171,7 @@
         _messageLabel.font = self.alertStyler.messageFont;
         _messageLabel.textColor = self.alertStyler.messageColor;
         _messageLabel.text = self.alertConfig.message;
+        _messageLabel.textAlignment = self.alertStyler.alignment;
     }
     
     return _messageLabel;

--- a/Pod/Classes/URBNAlertView.m
+++ b/Pod/Classes/URBNAlertView.m
@@ -154,7 +154,7 @@
     if (!_titleLabel) {
         _titleLabel = [UILabel new];
         _titleLabel.numberOfLines = 2;
-        _titleLabel.textAlignment = NSTextAlignmentCenter;
+        _titleLabel.textAlignment = self.alertStyler.titleAlignment;
         _titleLabel.adjustsFontSizeToFitWidth = YES;
         _titleLabel.font = self.alertStyler.titleFont;
         _titleLabel.textColor = self.alertStyler.titleColor;

--- a/Pod/Classes/URBNAlertView.m
+++ b/Pod/Classes/URBNAlertView.m
@@ -171,7 +171,7 @@
         _messageLabel.font = self.alertStyler.messageFont;
         _messageLabel.textColor = self.alertStyler.messageColor;
         _messageLabel.text = self.alertConfig.message;
-        _messageLabel.textAlignment = self.alertStyler.alignment;
+        _messageLabel.textAlignment = self.alertStyler.messageAlignment;
     }
     
     return _messageLabel;


### PR DESCRIPTION
The purpose of this PR is to add the option for setting the alignment of the alert view messages text.  If no alignment is given it defaults to the left.
