### PR TITLE
No Blur Rotation Bug

### DIFF
--- a/Pod/Classes/URBNAlertController.m
+++ b/Pod/Classes/URBNAlertController.m
@@ -129,6 +129,7 @@
     self.alertWindow = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     self.alertWindow.windowLevel = UIWindowLevelAlert;
     self.alertWindow.hidden = NO;
+    self.alertWindow.backgroundColor = [UIColor clearColor];
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(resignActive:) name:UIWindowDidBecomeKeyNotification object:nil];
 }

--- a/Pod/Classes/URBNAlertViewController.m
+++ b/Pod/Classes/URBNAlertViewController.m
@@ -249,16 +249,19 @@
 
 #pragma mark - Orientation Notifications
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
-    [self addBlurScreenshotOfSize:size];
-    
-    [coordinator animateAlongsideTransition:nil completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
-        [self addBlurScreenshot];
-    }];
+    if (self.alertStyler.blurEnabled.boolValue) {
+        [self addBlurScreenshotOfSize:size];
+        
+        [coordinator animateAlongsideTransition:nil completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+            [self addBlurScreenshot];
+        }];
+    }
 }
 
 - (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
     [super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
-    if (![UIViewController instancesRespondToSelector:@selector(viewWillTransitionToSize:withTransitionCoordinator:)]) {
+    
+    if (self.alertStyler.blurEnabled.boolValue && ![UIViewController instancesRespondToSelector:@selector(viewWillTransitionToSize:withTransitionCoordinator:)]) {
         CGSize size = self.viewForScreenshot.bounds.size;
         size.height = size.width;
         size.width = self.viewForScreenshot.bounds.size.height;
@@ -268,7 +271,8 @@
 
 - (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {
     [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
-    if (![UIViewController instancesRespondToSelector:@selector(viewWillTransitionToSize:withTransitionCoordinator:)]) {
+
+    if (self.alertStyler.blurEnabled.boolValue && ![UIViewController instancesRespondToSelector:@selector(viewWillTransitionToSize:withTransitionCoordinator:)]) {
         [self addBlurScreenshot];
     }
 }


### PR DESCRIPTION
When blur is not set, this will not create a blur view on rotation.

This also fixes an issue with the view disappearing when you rotate and only set a `backgroundViewTintColor`
