### PR TITLE
Fixing bug in viewDidAppear

### DIFF
--- a/URBNAlert.podspec
+++ b/URBNAlert.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "URBNAlert"
-  s.version          = "1.5"
+  s.version          = "1.5.1"
   s.summary          = "A custom alert view based off of UIAlertController but highly customizable."
   s.homepage         = "https://github.com/urbn/URBNAlert"
   s.license          = 'MIT'


### PR DESCRIPTION
- If the alert was passive and on touch presented a modal, if that modal was dismissed before the alert dismissed behind it, it would add another alertView on to the screen
