### PR TITLE
Multiple text inputs

### DIFF
--- a/Example/Tests/URBNAlertTests.m
+++ b/Example/Tests/URBNAlertTests.m
@@ -76,16 +76,6 @@
     [uac addAction:[URBNAlertAction actionWithTitle:@"btn" actionType:URBNAlertActionTypeNormal actionCompleted:nil]];
     XCTAssertNoThrow([uac show]);
     
-    // Test 1 input
-    uac = [[URBNAlertViewController alloc] initWithTitle:@"Title" message:@"Message"];
-    [uac addTextFieldWithConfigurationHandler:nil];
-    XCTAssertNoThrow([uac show]);
-    
-    // Test 2 input
-    uac = [[URBNAlertViewController alloc] initWithTitle:@"Title" message:@"Message"];
-    [uac addTextFieldWithConfigurationHandler:nil];
-    XCTAssertThrows([uac addTextFieldWithConfigurationHandler:nil]);
-    
     // Test nil title & message
     uac = [[URBNAlertViewController alloc] initWithTitle:nil message:nil];
     [uac addAction:[URBNAlertAction actionWithTitle:@"btn" actionType:URBNAlertActionTypeNormal actionCompleted:nil]];

--- a/Example/URBNAlert/URBNViewController.m
+++ b/Example/URBNAlert/URBNViewController.m
@@ -141,15 +141,31 @@
 
 
 - (IBAction)activeAlertInputTouch:(id)sender {
-    URBNAlertViewController *uac = [[URBNAlertViewController alloc] initWithTitle:@"Input Alert" message:@"Message and message and message and going on forever and ever. Message and message and message and going on forever and ever. Message and message and message and going on forever and ever. Message and message and message and going on forever and ever. and message and message and going on forever and ever." view:nil];
+    URBNAlertViewController *uac = [[URBNAlertViewController alloc] initWithTitle:@"Input Alert" message:@"Enter some info bro:" view:nil];
     
     [uac addAction:[URBNAlertAction actionWithTitle:@"Done" actionType:URBNAlertActionTypeNormal actionCompleted:^(URBNAlertAction *action) {
-        NSLog(@"input: %@", uac.textField.text);
+        NSLog(@"input 1: %@", [[uac.textFields objectAtIndex:0] text]);
+        NSLog(@"input 2: %@", [[uac.textFields objectAtIndex:1] text]);
+        NSLog(@"input 3: %@", [[uac.textFields objectAtIndex:2] text]);
     }]];
     
     [uac addTextFieldWithConfigurationHandler:^(UITextField *textField) {
         textField.borderStyle = UITextBorderStyleRoundedRect;
         textField.placeholder = @"e-mail";
+        textField.returnKeyType = UIReturnKeyDone;
+        textField.keyboardType = UIKeyboardTypeEmailAddress;
+    }];
+    
+    [uac addTextFieldWithConfigurationHandler:^(UITextField *textField) {
+        textField.borderStyle = UITextBorderStyleRoundedRect;
+        textField.placeholder = @"password";
+        textField.returnKeyType = UIReturnKeyDone;
+        textField.keyboardType = UIKeyboardTypeEmailAddress;
+    }];
+    
+    [uac addTextFieldWithConfigurationHandler:^(UITextField *textField) {
+        textField.borderStyle = UITextBorderStyleRoundedRect;
+        textField.placeholder = @"confirm";
         textField.returnKeyType = UIReturnKeyDone;
         textField.keyboardType = UIKeyboardTypeEmailAddress;
     }];
@@ -167,7 +183,8 @@
     [uac addAction:[URBNAlertAction actionWithTitle:@"Done" actionType:URBNAlertActionTypeNormal dismissOnActionComplete:NO actionCompleted:^(URBNAlertAction *action) {
         [weakUac startLoading];
         
-        if (weakUac.textField.text.length != 5) {
+        UITextField *textField = weakUac.textFields.firstObject;
+        if (textField.text.length != 5) {
             double delayInSeconds = 2.0;
             dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
             dispatch_after(popTime, dispatch_get_main_queue(), ^(void){

--- a/Example/URBNAlert/URBNViewController.m
+++ b/Example/URBNAlert/URBNViewController.m
@@ -144,7 +144,7 @@
     URBNAlertViewController *uac = [[URBNAlertViewController alloc] initWithTitle:@"Input Alert" message:@"Enter some info bro:" view:nil];
     
     [uac addAction:[URBNAlertAction actionWithTitle:@"Done" actionType:URBNAlertActionTypeNormal actionCompleted:^(URBNAlertAction *action) {
-        NSLog(@"input 1: %@", [[uac textFieldAtIndex:0] text]);
+        NSLog(@"input 1: %@", uac.textField.text);
         NSLog(@"input 2: %@", [[uac textFieldAtIndex:1] text]);
         NSLog(@"input 3: %@", [[uac textFieldAtIndex:2] text]);
     }]];

--- a/Example/URBNAlert/URBNViewController.m
+++ b/Example/URBNAlert/URBNViewController.m
@@ -181,14 +181,14 @@
     
     __weak typeof(uac) weakUac = uac;
     [uac addAction:[URBNAlertAction actionWithTitle:@"Done" actionType:URBNAlertActionTypeNormal dismissOnActionComplete:NO actionCompleted:^(URBNAlertAction *action) {
-        [weakUac startLoading];
+        [weakUac startLoadingTextFieldAtIndex:0];
         
         UITextField *textField = weakUac.textFields.firstObject;
         if (textField.text.length != 5) {
             double delayInSeconds = 2.0;
             dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
             dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
-                [weakUac stopLoading];
+                [weakUac stopLoadingTextField];
                 [weakUac showInputError:@"Error! must enter 5 characters. The error can span multiple lines."];
             });
         }

--- a/Example/URBNAlert/URBNViewController.m
+++ b/Example/URBNAlert/URBNViewController.m
@@ -144,9 +144,9 @@
     URBNAlertViewController *uac = [[URBNAlertViewController alloc] initWithTitle:@"Input Alert" message:@"Enter some info bro:" view:nil];
     
     [uac addAction:[URBNAlertAction actionWithTitle:@"Done" actionType:URBNAlertActionTypeNormal actionCompleted:^(URBNAlertAction *action) {
-        NSLog(@"input 1: %@", [[uac.textFields objectAtIndex:0] text]);
-        NSLog(@"input 2: %@", [[uac.textFields objectAtIndex:1] text]);
-        NSLog(@"input 3: %@", [[uac.textFields objectAtIndex:2] text]);
+        NSLog(@"input 1: %@", [[uac textFieldAtIndex:0] text]);
+        NSLog(@"input 2: %@", [[uac textFieldAtIndex:1] text]);
+        NSLog(@"input 3: %@", [[uac textFieldAtIndex:2] text]);
     }]];
     
     [uac addTextFieldWithConfigurationHandler:^(UITextField *textField) {
@@ -183,7 +183,7 @@
     [uac addAction:[URBNAlertAction actionWithTitle:@"Done" actionType:URBNAlertActionTypeNormal dismissOnActionComplete:NO actionCompleted:^(URBNAlertAction *action) {
         [weakUac startLoadingTextFieldAtIndex:0];
         
-        UITextField *textField = weakUac.textFields.firstObject;
+        UITextField *textField = [weakUac textFieldAtIndex:0];
         if (textField.text.length != 5) {
             double delayInSeconds = 2.0;
             dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));

--- a/Pod/Classes/URBNAlertConfig.h
+++ b/Pod/Classes/URBNAlertConfig.h
@@ -10,11 +10,33 @@
 
 @interface URBNAlertConfig : NSObject
 
+/**
+ *  Title text for the alert
+ */
 @property (nonatomic, copy) NSString *title;
+
+/**
+ *  Message text for the alert
+ */
 @property (nonatomic, copy) NSString *message;
+
+/**
+ *  Array of actions added to the alert
+ */
 @property (nonatomic, copy) NSArray *actions;
+
+@property (nonatomic, copy) NSArray *inputs;
+
+/**
+ *  The view to present from when using showInView:
+ */
 @property (nonatomic, weak) UIView *presentationView;
+
 @property (nonatomic, assign) BOOL hasInput;
+
+/**
+ *  Flag if the alert is active. False = a passive alert
+ */
 @property (nonatomic, assign) BOOL isActiveAlert;
 
 /**

--- a/Pod/Classes/URBNAlertConfig.h
+++ b/Pod/Classes/URBNAlertConfig.h
@@ -25,14 +25,15 @@
  */
 @property (nonatomic, copy) NSArray *actions;
 
+/**
+ *  Array of UITextFields added to the array
+ */
 @property (nonatomic, copy) NSArray *inputs;
 
 /**
  *  The view to present from when using showInView:
  */
 @property (nonatomic, weak) UIView *presentationView;
-
-@property (nonatomic, assign) BOOL hasInput;
 
 /**
  *  Flag if the alert is active. False = a passive alert

--- a/Pod/Classes/URBNAlertStyle.h
+++ b/Pod/Classes/URBNAlertStyle.h
@@ -86,6 +86,11 @@
 @property (nonatomic, strong) NSNumber *textFieldMaxLength;
 
 /**
+ *  Vertical margin between textfields
+ */
+@property (nonatomic, strong) NSNumber *textFieldVerticalMargin;
+
+/**
  * Height of the alert's buttons
  */
 @property (nonatomic, strong) NSNumber *buttonHeight;

--- a/Pod/Classes/URBNAlertStyle.m
+++ b/Pod/Classes/URBNAlertStyle.m
@@ -116,6 +116,10 @@
     return _textFieldMaxLength ?: @25;
 }
 
+- (NSNumber *)textFieldVerticalMargin {
+    return _textFieldVerticalMargin ?: @8;
+}
+
 #pragma mark - Shadow
 - (NSNumber *)alertViewShadowRadius {
     return _alertViewShadowRadius ?: @2;
@@ -173,6 +177,7 @@
     styler.buttonCornerRadius = self.buttonCornerRadius;
     styler.alertCornerRadius = self.alertCornerRadius;
     styler.textFieldMaxLength = self.textFieldMaxLength;
+    styler.textFieldVerticalMargin = self.textFieldVerticalMargin;
     styler.buttonHeight = self.buttonHeight;
     styler.sectionVerticalMargin = self.sectionVerticalMargin;
     styler.labelHorizontalMargin = self.labelHorizontalMargin;

--- a/Pod/Classes/URBNAlertView.h
+++ b/Pod/Classes/URBNAlertView.h
@@ -19,12 +19,10 @@ typedef void(^URBNAlertViewTouched)(URBNAlertAction *action);
 
 @interface URBNAlertView : UIView <UITextFieldDelegate>
 
-- (instancetype)initWithAlertConfig:(URBNAlertConfig *)config alertStyler:(URBNAlertStyle *)alertStyler customView:(UIView *)customView textField:(UITextField *)textField;
+- (instancetype)initWithAlertConfig:(URBNAlertConfig *)config alertStyler:(URBNAlertStyle *)alertStyler customView:(UIView *)customView;
 
 - (void)setErrorLabelText:(NSString *)errorText;
-- (void)setLoadingState:(BOOL)newState;
-
-@property (nonatomic, weak) UITextField *textField;
+- (void)setLoadingState:(BOOL)newState toTextFieldAtIndex:(NSUInteger)index;
 
 // Blocks
 @property (nonatomic, copy) URBNAlertViewButtonTouched buttonTouchedBlock;

--- a/Pod/Classes/URBNAlertView.h
+++ b/Pod/Classes/URBNAlertView.h
@@ -22,7 +22,7 @@ typedef void(^URBNAlertViewTouched)(URBNAlertAction *action);
 - (instancetype)initWithAlertConfig:(URBNAlertConfig *)config alertStyler:(URBNAlertStyle *)alertStyler customView:(UIView *)customView;
 
 - (void)setErrorLabelText:(NSString *)errorText;
-- (void)setLoadingState:(BOOL)newState toTextFieldAtIndex:(NSUInteger)index;
+- (void)setLoadingState:(BOOL)newState forTextFieldAtIndex:(NSUInteger)index;
 
 // Blocks
 @property (nonatomic, copy) URBNAlertViewButtonTouched buttonTouchedBlock;

--- a/Pod/Classes/URBNAlertView.m
+++ b/Pod/Classes/URBNAlertView.m
@@ -284,7 +284,7 @@ static NSInteger const kURBNAlertViewHeightPadding = 80.f;
     }];
 }
 
-- (void)setLoadingState:(BOOL)newState toTextFieldAtIndex:(NSUInteger)index {
+- (void)setLoadingState:(BOOL)newState forTextFieldAtIndex:(NSUInteger)index {
     if (index < self.alertConfig.inputs.count) {
         UITextField *textField = [self.alertConfig.inputs objectAtIndex:index];
         

--- a/Pod/Classes/URBNAlertView.m
+++ b/Pod/Classes/URBNAlertView.m
@@ -36,7 +36,6 @@ static NSInteger const kURBNAlertViewHeightPadding = 80.f;
     if (self) {
         self.alertConfig = config;
         self.alertStyler = alertStyler;
-        //self.textField = textField;
         
         if (!customView) {
             // Give it a dummy view
@@ -60,9 +59,10 @@ static NSInteger const kURBNAlertViewHeightPadding = 80.f;
         [self addSubview:self.errorLabel];
         [self addSubview:self.customView];
         
-        if (self.alertConfig.inputs) {
+        NSMutableDictionary *mutableViews = [NSMutableDictionary dictionaryWithDictionary:@{@"_customView" : _customView, @"_titleLabel" : _titleLabel, @"_messageTextView" : _messageTextView, @"buttonContainer" : buttonContainer, @"_errorLabel" : _errorLabel}];
+
+        if (self.alertConfig.inputs && self.alertConfig.inputs.count > 0) {
             __weak typeof(self) weakSelf = self;
-            NSMutableDictionary *mutableViews = [NSMutableDictionary dictionaryWithDictionary:@{@"_customView" : _customView, @"_titleLabel" : _titleLabel, @"_messageTextView" : _messageTextView, @"buttonContainer" : buttonContainer, @"_errorLabel" : _errorLabel}];
             
             [self.alertConfig.inputs enumerateObjectsUsingBlock:^(UITextField *tf, NSUInteger idx, BOOL *stop) {
                 tf.translatesAutoresizingMaskIntoConstraints = NO;
@@ -70,12 +70,9 @@ static NSInteger const kURBNAlertViewHeightPadding = 80.f;
                 weakSelf.sectionCount++;
                 [weakSelf addSubview:tf];
             }];
-            
-            views = [mutableViews copy];
         }
-        else {
-            views = NSDictionaryOfVariableBindings(_customView, _titleLabel, _messageTextView, buttonContainer, _errorLabel);
-        }
+        
+        views = [mutableViews copy];
         
         // Add some buttons
         NSMutableArray *btns = [NSMutableArray new];
@@ -131,9 +128,9 @@ static NSInteger const kURBNAlertViewHeightPadding = 80.f;
         }
         else {
             NSMutableString *vertVfl = [NSMutableString stringWithString:@"V:|-titleVMargin-[_titleLabel]-msgVMargin-[_messageTextView]-cvMargin-[_customView]-cvMargin-"];
+          
             [self.alertConfig.inputs enumerateObjectsUsingBlock:^(UITextField *tf, NSUInteger idx, BOOL *stop) {
                 [vertVfl appendString:[NSString stringWithFormat:@"[textField%ld]-tfVMargin-", idx]];
-                
                 [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:[NSString stringWithFormat:@"H:|-lblHMargin-[textField%ld]-lblHMargin-|", idx] options:0 metrics:metrics views:views]];
             }];
             

--- a/Pod/Classes/URBNAlertViewController.h
+++ b/Pod/Classes/URBNAlertViewController.h
@@ -56,11 +56,6 @@ typedef void(^URBNAlertViewControllerFinishedDismissing)(BOOL wasTouchedOutside)
 @property (nonatomic, strong) URBNAlertConfig *alertConfig;
 
 /**
- *  The textField displayed in the alert, if added
- */
-@property (nonatomic, strong) NSArray *textFields;
-
-/**
  *  The customView displayed in the alert, if passed
  */
 @property (nonatomic, strong) UIView *customView;
@@ -123,6 +118,15 @@ typedef void(^URBNAlertViewControllerFinishedDismissing)(BOOL wasTouchedOutside)
  *  Enables all buttons and removes the textField loading spinner if present
  */
 - (void)stopLoadingTextField;
+
+/**
+ *  Helpers to get a textfield for a given index
+ *
+ *  @param index The index of the textfield you wish to get
+ *
+ *  @return
+ */
+- (UITextField *)textFieldAtIndex:(NSUInteger)index;
 
 /**
  *  Used to detect when the alert has completed its dismissing animation

--- a/Pod/Classes/URBNAlertViewController.h
+++ b/Pod/Classes/URBNAlertViewController.h
@@ -122,6 +122,11 @@ typedef void(^URBNAlertViewControllerFinishedDismissing)(BOOL wasTouchedOutside)
 - (void)stopLoadingTextField;
 
 /**
+ *  Getter for the 1st textField added to the alert. Kept for convenience & backwards compatability
+ */
+- (UITextField *)textField;
+
+/**
  *  Helpers to get a textfield for a given index
  *
  *  @param index The index of the textfield you wish to get

--- a/Pod/Classes/URBNAlertViewController.h
+++ b/Pod/Classes/URBNAlertViewController.h
@@ -117,12 +117,12 @@ typedef void(^URBNAlertViewControllerFinishedDismissing)(BOOL wasTouchedOutside)
  *  When called, the buttons are disabled until stopLoading is called.
  *  If a textField is present, a loading indicator is added
  */
-- (void)startLoading;
+- (void)startLoadingTextFieldAtIndex:(NSUInteger)index;
 
 /**
  *  Enables all buttons and removes the textField loading spinner if present
  */
-- (void)stopLoading;
+- (void)stopLoadingTextField;
 
 /**
  *  Used to detect when the alert has completed its dismissing animation

--- a/Pod/Classes/URBNAlertViewController.h
+++ b/Pod/Classes/URBNAlertViewController.h
@@ -58,7 +58,7 @@ typedef void(^URBNAlertViewControllerFinishedDismissing)(BOOL wasTouchedOutside)
 /**
  *  The textField displayed in the alert, if added
  */
-@property (nonatomic, strong) UITextField *textField;
+@property (nonatomic, strong) NSArray *textFields;
 
 /**
  *  The customView displayed in the alert, if passed

--- a/Pod/Classes/URBNAlertViewController.h
+++ b/Pod/Classes/URBNAlertViewController.h
@@ -109,8 +109,10 @@ typedef void(^URBNAlertViewControllerFinishedDismissing)(BOOL wasTouchedOutside)
 - (void)showInputError:(NSString *)errorText;
 
 /**
- *  When called, the buttons are disabled until stopLoading is called.
- *  If a textField is present, a loading indicator is added
+ *  When called, any buttons are disabled and the textfield at the given index 
+ *     animates with a loading indicator
+ *
+ *  @param index Index of the textfield you wish to animate
  */
 - (void)startLoadingTextFieldAtIndex:(NSUInteger)index;
 

--- a/Pod/Classes/URBNAlertViewController.m
+++ b/Pod/Classes/URBNAlertViewController.m
@@ -23,6 +23,7 @@
 @property (nonatomic, assign) BOOL alertVisible;
 @property (nonatomic, assign) BOOL viewControllerVisible;
 @property (nonatomic, readonly) UIView *viewForScreenshot;
+@property (nonatomic, strong) NSArray *textFields;
 
 @end
 
@@ -242,6 +243,10 @@
 
 - (void)stopLoadingTextField {
     [self.alertView setLoadingState:NO forTextFieldAtIndex:0];
+}
+
+- (UITextField *)textFieldAtIndex:(NSUInteger)index {
+    return [self.textFields objectAtIndex:index];
 }
 
 - (UIView *)viewForScreenshot {

--- a/Pod/Classes/URBNAlertViewController.m
+++ b/Pod/Classes/URBNAlertViewController.m
@@ -236,12 +236,12 @@
     [self.alertView setErrorLabelText:errorText];
 }
 
-- (void)startLoading {
-    [self.alertView setLoadingState:YES];
+- (void)startLoadingTextFieldAtIndex:(NSUInteger)index {
+    [self.alertView setLoadingState:YES forTextFieldAtIndex:index];
 }
 
-- (void)stopLoading {
-    [self.alertView setLoadingState:NO];
+- (void)stopLoadingTextField {
+    [self.alertView setLoadingState:NO forTextFieldAtIndex:0];
 }
 
 - (UIView *)viewForScreenshot {

--- a/Pod/Classes/URBNAlertViewController.m
+++ b/Pod/Classes/URBNAlertViewController.m
@@ -134,18 +134,21 @@
 }
 
 - (void)addTextFieldWithConfigurationHandler:(void (^)(UITextField *textField))configurationHandler {
-    NSAssert(!self.textField, @"URBNAlertController: Active alerts only supports up 1 input text field at the moment. Please create an issue if you want more!");
+    NSMutableArray *inputs = [self.alertConfig.inputs mutableCopy] ?: [NSMutableArray new];
+    
+    //NSAssert(!self.textField, @"URBNAlertController: Active alerts only supports up 1 input text field at the moment. Please create an issue if you want more!");
     
     UITextField *textField = [UITextField new];
     if (configurationHandler) {
         configurationHandler(textField);
     }
     
-    self.textField = textField;
+    [inputs addObject:textField];
+    self.alertConfig.inputs = inputs;
 }
 
 - (void)show {
-    self.alertView = [[URBNAlertView alloc] initWithAlertConfig:self.alertConfig alertStyler:self.alertStyler customView:self.customView textField:self.textField];
+    self.alertView = [[URBNAlertView alloc] initWithAlertConfig:self.alertConfig alertStyler:self.alertStyler customView:self.customView];
     self.alertView.alpha = 0;
     self.alertView.translatesAutoresizingMaskIntoConstraints = NO;
     
@@ -243,6 +246,11 @@
 
 - (UIView *)viewForScreenshot {
     return self.alertConfig.presentationView ?: self.alertController.presentingWindow;
+}
+
+#pragma mark - Getters
+- (NSArray *)textFields {
+    return self.alertConfig.inputs;
 }
 
 #pragma mark - Action

--- a/Pod/Classes/URBNAlertViewController.m
+++ b/Pod/Classes/URBNAlertViewController.m
@@ -184,7 +184,6 @@
     [self dismissAlert:nil];
 }
 
-#pragma mark - Methods
 - (void)setVisible:(BOOL)visible animated:(BOOL)animated completion:(void (^)(URBNAlertViewController *alertVC, BOOL finished))complete {
     self.alertVisible = visible;
     
@@ -245,7 +244,15 @@
 }
 
 - (UITextField *)textFieldAtIndex:(NSUInteger)index {
-    return [self.alertConfig.inputs objectAtIndex:index];
+    if (index < self.alertConfig.inputs.count)  {
+        return [self.alertConfig.inputs objectAtIndex:index];
+    }
+    
+    return nil;
+}
+
+- (UITextField *)textField {
+    return [self textFieldAtIndex:0];
 }
 
 - (UIView *)viewForScreenshot {

--- a/Pod/Classes/URBNAlertViewController.m
+++ b/Pod/Classes/URBNAlertViewController.m
@@ -22,8 +22,8 @@
 @property (nonatomic, strong) UIImageView *blurImageView;
 @property (nonatomic, assign) BOOL alertVisible;
 @property (nonatomic, assign) BOOL viewControllerVisible;
+@property (nonatomic, assign) NSUInteger indexOfLoadingTextField;
 @property (nonatomic, readonly) UIView *viewForScreenshot;
-@property (nonatomic, strong) NSArray *textFields;
 
 @end
 
@@ -137,8 +137,6 @@
 - (void)addTextFieldWithConfigurationHandler:(void (^)(UITextField *textField))configurationHandler {
     NSMutableArray *inputs = [self.alertConfig.inputs mutableCopy] ?: [NSMutableArray new];
     
-    //NSAssert(!self.textField, @"URBNAlertController: Active alerts only supports up 1 input text field at the moment. Please create an issue if you want more!");
-    
     UITextField *textField = [UITextField new];
     if (configurationHandler) {
         configurationHandler(textField);
@@ -238,24 +236,20 @@
 }
 
 - (void)startLoadingTextFieldAtIndex:(NSUInteger)index {
+    self.indexOfLoadingTextField = index;
     [self.alertView setLoadingState:YES forTextFieldAtIndex:index];
 }
 
 - (void)stopLoadingTextField {
-    [self.alertView setLoadingState:NO forTextFieldAtIndex:0];
+    [self.alertView setLoadingState:NO forTextFieldAtIndex:self.indexOfLoadingTextField];
 }
 
 - (UITextField *)textFieldAtIndex:(NSUInteger)index {
-    return [self.textFields objectAtIndex:index];
+    return [self.alertConfig.inputs objectAtIndex:index];
 }
 
 - (UIView *)viewForScreenshot {
     return self.alertConfig.presentationView ?: self.alertController.presentingWindow;
-}
-
-#pragma mark - Getters
-- (NSArray *)textFields {
-    return self.alertConfig.inputs;
 }
 
 #pragma mark - Action

--- a/URBNAlert.podspec
+++ b/URBNAlert.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "URBNAlert"
-  s.version          = "1.5.1"
+  s.version          = "1.6"
   s.summary          = "A custom alert view based off of UIAlertController but highly customizable."
   s.homepage         = "https://github.com/urbn/URBNAlert"
   s.license          = 'MIT'


### PR DESCRIPTION
This PR allows the use of multiple UITextFields in an URBNAlert. Previously only 1 was supported. 

A convenience method `textFieldAtIndex` was added to URBNAlertViewController, and is now how you access a textField. The index correlates to the order in which you added the textFields.

The `setLoading` method also had to be updated to handle multiple textInputs. 
