### PR TITLE
Cancel action & Action enabled state

### DIFF
--- a/Example/URBNAlert/URBNViewController.m
+++ b/Example/URBNAlert/URBNViewController.m
@@ -163,8 +163,11 @@
 - (IBAction)activeAlertValidateInput:(id)sender {
     URBNAlertViewController *uac = [[URBNAlertViewController alloc] initWithTitle:@"Validated Input Alert" message:@"Input must be 5 characters long to pass."];
     
+    [uac addAction:[URBNAlertAction actionWithTitle:@"Cancel" actionType:URBNAlertActionTypeCancel actionCompleted:nil]];
+    
     __weak typeof(uac) weakUac = uac;
-    [uac addAction:[URBNAlertAction actionWithTitle:@"Done" actionType:URBNAlertActionTypeNormal dismissOnActionComplete:NO actionCompleted:^(URBNAlertAction *action) {
+    
+    [uac addAction:[URBNAlertAction actionWithTitle:@"Submit" actionType:URBNAlertActionTypeNormal dismissOnActionComplete:NO actionCompleted:^(URBNAlertAction *action) {
         [weakUac startLoading];
         
         if (weakUac.textField.text.length != 5) {
@@ -173,6 +176,7 @@
             dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
                 [weakUac stopLoading];
                 [weakUac showInputError:@"Error! must enter 5 characters. The error can span multiple lines."];
+                [action setEnabled:NO];
             });
         }
         else {

--- a/Example/URBNAlert/URBNViewController.m
+++ b/Example/URBNAlert/URBNViewController.m
@@ -29,7 +29,7 @@
     // Set global stlying. This can be done sometime during app launch. You can change style options per alert as well.
     self.alertController = [URBNAlertController sharedInstance];
     self.alertController.alertStyler.buttonBackgroundColor = [UIColor blueColor];
-    self.alertController.alertStyler.destructionButtonBackgroundColor = [UIColor greenColor];
+    self.alertController.alertStyler.cancelButtonTitleColor = [UIColor redColor];
     
     self.navigationItem.title = @"URBNAlert";
     
@@ -178,6 +178,9 @@
 
 - (IBAction)activeAlertValidateInput:(id)sender {
     URBNAlertViewController *uac = [[URBNAlertViewController alloc] initWithTitle:@"Validated Input Alert" message:@"Input must be 5 characters long to pass."];
+    uac.alertStyler.disabledButtonTitleColor = [UIColor orangeColor];
+    uac.alertStyler.disabledButtonBackgroundColor = [UIColor blackColor];
+    uac.alertStyler.disabledButtonAlpha = @1.f;
     
     [uac addAction:[URBNAlertAction actionWithTitle:@"Cancel" actionType:URBNAlertActionTypeCancel actionCompleted:nil]];
     

--- a/Pod/Classes/URBNAlertAction.h
+++ b/Pod/Classes/URBNAlertAction.h
@@ -13,6 +13,7 @@
 typedef NS_ENUM(NSInteger, URBNAlertActionType) {
     URBNAlertActionTypeNormal,
     URBNAlertActionTypeDestructive,
+    URBNAlertActionTypeCancel,
     URBNAlertActionTypePassive
 };
 

--- a/Pod/Classes/URBNAlertAction.h
+++ b/Pod/Classes/URBNAlertAction.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class URBNAlertAction;
+@class URBNAlertAction, URBNAlertActionButton;
 
 typedef NS_ENUM(NSInteger, URBNAlertActionType) {
     URBNAlertActionTypeNormal,
@@ -24,6 +24,7 @@ typedef void(^URBNAlertCompletion)(URBNAlertAction *action);
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, assign) BOOL dismissOnCompletion;
 @property (nonatomic, assign) URBNAlertActionType actionType;
+@property (nonatomic, weak) URBNAlertActionButton *actionButton;
 
 @property (nonatomic, copy) URBNAlertCompletion completionBlock;
 - (void)setCompletionBlock:(URBNAlertCompletion)completionBlock;
@@ -32,6 +33,18 @@ typedef void(^URBNAlertCompletion)(URBNAlertAction *action);
 
 + (URBNAlertAction *)actionWithTitle:(NSString *)title actionType:(URBNAlertActionType)actionType dismissOnActionComplete:(BOOL)dismiss actionCompleted:(URBNAlertCompletion)completionBlock;
 
+/**
+ *  Returns whether the action is a button or not
+ *
+ *  @return BOOL
+ */
 - (BOOL)isButton;
+
+/**
+ *  If the action is a button, set the enabled state of that button.
+ *
+ *  @param enabled 
+ */
+- (void)setEnabled:(BOOL)enabled;
 
 @end

--- a/Pod/Classes/URBNAlertAction.m
+++ b/Pod/Classes/URBNAlertAction.m
@@ -8,6 +8,7 @@
 
 #import "URBNAlertAction.h"
 #import "URBNAlertView.h"
+#import "URBNAlertStyle.h"
 
 @implementation URBNAlertAction
 
@@ -26,14 +27,23 @@
 }
 
 - (BOOL)isButton {
-    return (self.actionType == URBNAlertActionTypeNormal || self.actionType == URBNAlertActionTypeDestructive || self.actionType == URBNAlertActionTypeCancel);
+    return (self.actionType != URBNAlertActionTypePassive);
 }
 
 - (void)setEnabled:(BOOL)enabled {
-    if (self.isButton && self.actionButton) {
+    if (self.isButton && self.actionButton && self.actionType != URBNAlertActionTypeCancel) {
         [self.actionButton setEnabled:enabled];
-        self.actionButton.alpha = enabled ? 1.f : 0.5f;
+        [self styleButton:self.actionButton isEnabled:enabled];
     }
+}
+
+- (void)styleButton:(URBNAlertActionButton *)actionButton isEnabled:(BOOL)enabled {
+    UIColor *titleColor = [self.actionButton.alertStyler buttonTitleColorForActionType:actionButton.actionType isEnabled:enabled];
+    UIColor *bgColor = [self.actionButton.alertStyler buttonBackgroundColorForActionType:actionButton.actionType isEnabled:enabled];
+    
+    [actionButton setTitleColor:titleColor forState:UIControlStateNormal];
+    [actionButton setBackgroundColor:bgColor];
+    actionButton.alpha = enabled ? 1.f : self.actionButton.alertStyler.disabledButtonAlpha.floatValue;
 }
 
 @end

--- a/Pod/Classes/URBNAlertAction.m
+++ b/Pod/Classes/URBNAlertAction.m
@@ -7,6 +7,7 @@
 //
 
 #import "URBNAlertAction.h"
+#import "URBNAlertView.h"
 
 @implementation URBNAlertAction
 
@@ -26,6 +27,13 @@
 
 - (BOOL)isButton {
     return (self.actionType == URBNAlertActionTypeNormal || self.actionType == URBNAlertActionTypeDestructive || self.actionType == URBNAlertActionTypeCancel);
+}
+
+- (void)setEnabled:(BOOL)enabled {
+    if (self.isButton && self.actionButton) {
+        [self.actionButton setEnabled:enabled];
+        self.actionButton.alpha = enabled ? 1.f : 0.5f;
+    }
 }
 
 @end

--- a/Pod/Classes/URBNAlertAction.m
+++ b/Pod/Classes/URBNAlertAction.m
@@ -25,7 +25,7 @@
 }
 
 - (BOOL)isButton {
-    return (self.actionType == URBNAlertActionTypeNormal || self.actionType == URBNAlertActionTypeDestructive);
+    return (self.actionType == URBNAlertActionTypeNormal || self.actionType == URBNAlertActionTypeDestructive || self.actionType == URBNAlertActionTypeCancel);
 }
 
 @end

--- a/Pod/Classes/URBNAlertController.m
+++ b/Pod/Classes/URBNAlertController.m
@@ -58,10 +58,10 @@
             }
             
             // If the queue is empty, remove the window. If not keep visible to present next alert(s)
-            if (!self.queue || self.queue.count == 0) {
-                [self.presentingWindow makeKeyAndVisible];
-                self.alertWindow.hidden = YES;
-                self.alertWindow = nil;
+            if (!weakSelf.queue || weakSelf.queue.count == 0) {
+                [weakSelf.presentingWindow makeKeyAndVisible];
+                weakSelf.alertWindow.hidden = YES;
+                weakSelf.alertWindow = nil;
             }
         }];
         

--- a/Pod/Classes/URBNAlertStyle.h
+++ b/Pod/Classes/URBNAlertStyle.h
@@ -26,6 +26,16 @@
 @property (nonatomic, strong) UIColor *destructiveButtonTitleColor;
 
 /**
+ * Background color of the cancel button for an active alert
+ */
+@property (nonatomic, strong) UIColor *cancelButtonBackgroundColor;
+
+/**
+ * Text color of cancel button colors
+ */
+@property (nonatomic, strong) UIColor *cancelButtonTitleColor;
+
+/**
  * Text color of the button titles
  */
 @property (nonatomic, strong) UIColor *buttonTitleColor;

--- a/Pod/Classes/URBNAlertStyle.h
+++ b/Pod/Classes/URBNAlertStyle.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import "URBNAlertAction.h"
 
 @interface URBNAlertStyle : NSObject <NSCopying>
 /**
@@ -34,6 +35,21 @@
  * Text color of cancel button colors
  */
 @property (nonatomic, strong) UIColor *cancelButtonTitleColor;
+
+/**
+ * Background color of a disabled button for an active alert
+ */
+@property (nonatomic, strong) UIColor *disabledButtonBackgroundColor;
+
+/**
+ * Text color of a disabled button
+ */
+@property (nonatomic, strong) UIColor *disabledButtonTitleColor;
+
+/**
+ * Alpha value of a disabled button
+ */
+@property (nonatomic, strong) NSNumber *disabledButtonAlpha;
 
 /**
  * Text color of the button titles
@@ -194,5 +210,23 @@
  * Text color of the error label text
  */
 @property (nonatomic, strong) UIFont *errorTextFont;
+
+/**
+ *  Returns the correct background color for given an actionType
+ *
+ *  @param actionType Action type associated with the button
+ *
+ *  @return
+ */
+- (UIColor *)buttonTitleColorForActionType:(URBNAlertActionType)actionType isEnabled:(BOOL)enabled;
+
+/**
+ *  Returns the correct title color for given an actionType
+ *
+ *  @param actionType Action type associated with the button
+ *
+ *  @return
+ */
+- (UIColor *)buttonBackgroundColorForActionType:(URBNAlertActionType)actionType isEnabled:(BOOL)enabled;
 
 @end

--- a/Pod/Classes/URBNAlertStyle.m
+++ b/Pod/Classes/URBNAlertStyle.m
@@ -66,6 +66,14 @@
     return _destructiveButtonTitleColor ?: [UIColor whiteColor];
 }
 
+- (UIColor *)cancelButtonBackgroundColor {
+    return _destructionButtonBackgroundColor ?: [UIColor lightGrayColor];
+}
+
+- (UIColor *)cancelButtonTitleColor {
+    return _destructiveButtonTitleColor ?: [UIColor whiteColor];
+}
+
 - (NSNumber *)buttonCornerRadius {
     return _buttonCornerRadius ?: @8;
 }
@@ -161,6 +169,8 @@
     styler.buttonBackgroundColor = self.buttonBackgroundColor;
     styler.destructionButtonBackgroundColor = self.destructionButtonBackgroundColor;
     styler.destructiveButtonTitleColor = self.destructiveButtonTitleColor;
+    styler.cancelButtonBackgroundColor = self.cancelButtonBackgroundColor;
+    styler.cancelButtonTitleColor = self.cancelButtonTitleColor;
     styler.buttonTitleColor = self.buttonTitleColor;
     styler.backgroundColor = self.backgroundColor;
     styler.titleColor = self.titleColor;

--- a/Pod/Classes/URBNAlertStyle.m
+++ b/Pod/Classes/URBNAlertStyle.m
@@ -167,6 +167,55 @@
     return _blurTintColor;
 }
 
+#pragma mark - Disabled button styling
+- (UIColor *)buttonTitleColorForActionType:(URBNAlertActionType)actionType isEnabled:(BOOL)enabled {
+    if (self.disabledButtonTitleColor && !enabled) {
+        return self.disabledButtonTitleColor;
+    }
+    
+    switch (actionType) {
+        case URBNAlertActionTypeCancel:
+            return self.cancelButtonTitleColor;
+            break;
+        case URBNAlertActionTypeNormal:
+            return self.buttonTitleColor;
+            break;
+        case URBNAlertActionTypeDestructive:
+            return self.destructiveButtonTitleColor;
+            break;
+        default:
+            return self.buttonTitleColor;
+            break;
+    }
+}
+
+- (UIColor *)buttonBackgroundColorForActionType:(URBNAlertActionType)actionType isEnabled:(BOOL)enabled {
+    if (self.disabledButtonBackgroundColor && !enabled) {
+        return self.disabledButtonBackgroundColor;
+    }
+    
+    switch (actionType) {
+        case URBNAlertActionTypeCancel:
+            return self.cancelButtonBackgroundColor;
+            break;
+        case URBNAlertActionTypeNormal:
+            return self.buttonBackgroundColor;
+            break;
+        case URBNAlertActionTypeDestructive:
+            return self.destructionButtonBackgroundColor;
+            break;
+        default:
+            return self.buttonBackgroundColor;
+            break;
+    }
+}
+
+
+- (NSNumber *)disabledButtonAlpha {
+    return _disabledButtonAlpha ?: @(0.5f);
+}
+
+#pragma mark - Copying
 - (instancetype)copyWithZone:(NSZone *)zone {
     URBNAlertStyle *styler = [URBNAlertStyle new];
     

--- a/Pod/Classes/URBNAlertView.h
+++ b/Pod/Classes/URBNAlertView.h
@@ -37,6 +37,7 @@ typedef void(^URBNAlertViewTouched)(URBNAlertAction *action);
 @interface URBNAlertActionButton : UIButton
 
 @property (nonatomic, assign) URBNAlertActionType actionType;
+@property (nonatomic, weak) URBNAlertStyle *alertStyler;
 
 @end
 

--- a/Pod/Classes/URBNAlertView.h
+++ b/Pod/Classes/URBNAlertView.h
@@ -7,11 +7,11 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "URBNAlertAction.h"
 
 @class URBNAlertController;
 @class URBNAlertView;
 @class URBNAlertConfig;
-@class URBNAlertAction;
 @class URBNAlertStyle;
 
 typedef void(^URBNAlertViewButtonTouched)(URBNAlertAction *action);
@@ -34,3 +34,11 @@ typedef void(^URBNAlertViewTouched)(URBNAlertAction *action);
 - (void)setAlertViewTouchedBlock:(URBNAlertViewTouched)alertViewTouchedBlock;
 
 @end
+
+// URBNAlertActionButton
+@interface URBNAlertActionButton : UIButton
+
+@property (nonatomic, assign) URBNAlertActionType actionType;
+
+@end
+

--- a/Pod/Classes/URBNAlertView.m
+++ b/Pod/Classes/URBNAlertView.m
@@ -248,6 +248,10 @@ static NSInteger const kURBNAlertViewHeightPadding = 80.f;
         titleColor = self.alertStyler.destructiveButtonTitleColor;
         bgColor = self.alertStyler.destructionButtonBackgroundColor;
     }
+    else if (action.actionType == URBNAlertActionTypeCancel) {
+        titleColor = self.alertStyler.cancelButtonTitleColor;
+        bgColor = self.alertStyler.cancelButtonBackgroundColor;
+    }
     
     UIButton *btn = [UIButton buttonWithType:UIButtonTypeCustom];
     btn.translatesAutoresizingMaskIntoConstraints = NO;

--- a/Pod/Classes/URBNAlertView.m
+++ b/Pod/Classes/URBNAlertView.m
@@ -14,6 +14,10 @@
 #import <URBNConvenience/UIView+URBNLayout.h>
 #import <URBNConvenience/URBNMacros.h>
 
+@implementation URBNAlertActionButton
+
+@end
+
 static NSInteger const kURBNAlertViewHeightPadding = 80.f;
 
 @interface URBNAlertView()
@@ -78,9 +82,10 @@ static NSInteger const kURBNAlertViewHeightPadding = 80.f;
         __weak typeof(self) weakSelf = self;
         [self.alertConfig.actions enumerateObjectsUsingBlock:^(URBNAlertAction *action, NSUInteger idx, BOOL *stop) {
             if (action.isButton) {
-                UIButton *btn = [weakSelf createAlertViewButtonWithAction:action atIndex:idx];
+                URBNAlertActionButton *btn = [weakSelf createAlertViewButtonWithAction:action atIndex:idx];
                 [buttonContainer addSubview:btn];
                 [btns addObject:btn];
+                action.actionButton = btn;
             }
         }];
         
@@ -240,7 +245,7 @@ static NSInteger const kURBNAlertViewHeightPadding = 80.f;
 }
 
 #pragma mark - Methods
-- (UIButton *)createAlertViewButtonWithAction:(URBNAlertAction *)action atIndex:(NSInteger)index {
+- (URBNAlertActionButton *)createAlertViewButtonWithAction:(URBNAlertAction *)action atIndex:(NSInteger)index {
     UIColor *bgColor = self.alertStyler.buttonBackgroundColor;
     UIColor *titleColor = self.alertStyler.buttonTitleColor;
     
@@ -253,12 +258,13 @@ static NSInteger const kURBNAlertViewHeightPadding = 80.f;
         bgColor = self.alertStyler.cancelButtonBackgroundColor;
     }
     
-    UIButton *btn = [UIButton buttonWithType:UIButtonTypeCustom];
+    URBNAlertActionButton *btn = [URBNAlertActionButton buttonWithType:UIButtonTypeCustom];
     btn.translatesAutoresizingMaskIntoConstraints = NO;
     btn.backgroundColor = bgColor;
     btn.titleLabel.font = self.alertStyler.buttonFont;
     btn.layer.cornerRadius = self.alertStyler.buttonCornerRadius.floatValue;
     btn.tag = index;
+    btn.actionType = action.actionType;
     
     [btn setTitle:action.title forState:UIControlStateNormal];
     [btn setTitleColor:titleColor forState:UIControlStateNormal];
@@ -293,9 +299,11 @@ static NSInteger const kURBNAlertViewHeightPadding = 80.f;
 }
 
 - (void)setButtonsEnabled:(BOOL)enabled {
-    for (UIButton *btn in self.buttons) {
-        btn.enabled = enabled;
-        btn.alpha = enabled ? 1.f : 0.5f;
+    for (URBNAlertActionButton *btn in self.buttons) {
+        if (btn.actionType != URBNAlertActionTypeCancel) {
+            btn.enabled = enabled;
+            btn.alpha = enabled ? 1.f : 0.5f;
+        }
     }
 }
 

--- a/Pod/Classes/URBNAlertView.m
+++ b/Pod/Classes/URBNAlertView.m
@@ -276,6 +276,7 @@ static NSInteger const kURBNAlertViewHeightPadding = 80.f;
     btn.layer.cornerRadius = self.alertStyler.buttonCornerRadius.floatValue;
     btn.tag = index;
     btn.actionType = action.actionType;
+    btn.alertStyler = self.alertStyler;
     
     [btn setTitle:action.title forState:UIControlStateNormal];
     [btn setTitleColor:titleColor forState:UIControlStateNormal];
@@ -312,11 +313,8 @@ static NSInteger const kURBNAlertViewHeightPadding = 80.f;
 }
 
 - (void)setButtonsEnabled:(BOOL)enabled {
-    for (URBNAlertActionButton *btn in self.buttons) {
-        if (btn.actionType != URBNAlertActionTypeCancel) {
-            btn.enabled = enabled;
-            btn.alpha = enabled ? 1.f : 0.5f;
-        }
+    for (URBNAlertAction *action in self.alertConfig.actions) {
+        [action setEnabled:enabled];
     }
 }
 

--- a/Pod/Classes/URBNAlertViewController.m
+++ b/Pod/Classes/URBNAlertViewController.m
@@ -105,7 +105,7 @@
     
     self.alertConfig.actions = [actions copy];
     
-    if (action.actionType != URBNAlertActionTypePassive) {
+    if (action.actionType != buttonPassive) {
         self.alertConfig.isActiveAlert = YES;
     }
 }

--- a/Pod/Classes/URBNAlertViewController.m
+++ b/Pod/Classes/URBNAlertViewController.m
@@ -105,7 +105,7 @@
     
     self.alertConfig.actions = [actions copy];
     
-    if (action.actionType != buttonPassive) {
+    if (action.actionType != URBNAlertActionTypePassive) {
         self.alertConfig.isActiveAlert = YES;
     }
 }


### PR DESCRIPTION
This PR covers issue 24: https://github.com/urbn/URBNAlert/issues/24
- Added `URBNAlertActionTypeCancel`. Actions that are canceled never get disabled when loading
- Added some style options for Cancel actions
- Added `setEnabled:` method to `URBNAlertAction`. If that action is a button, you can now disabled/enabled it 
