### PR TITLE
Added alert max/min width properties to style

### DIFF
--- a/Example/URBNAlert/URBNViewController.m
+++ b/Example/URBNAlert/URBNViewController.m
@@ -50,7 +50,6 @@
     [uac addAction:[URBNAlertAction actionWithTitle:@"Done" actionType:URBNAlertActionTypeNormal actionCompleted:^(URBNAlertAction *action) {
           // Do something
     }]];
-    
     [uac show];
 }
 
@@ -75,9 +74,9 @@
 
 - (IBAction)activeAlertColoredTouch:(id)sender {
     URBNAlertViewController *uac = [[URBNAlertViewController alloc] initWithTitle:@"Custom Styled Alert" message:@"You can change the fonts, colors, button size, corner radius, and much more."];
-    uac.alertStyler.buttonBackgroundColor = [UIColor yellowColor];
-    uac.alertStyler.destructionButtonBackgroundColor = [UIColor purpleColor];
-    uac.alertStyler.destructiveButtonTitleColor = [UIColor greenColor];
+    uac.alertStyler.buttonBackgroundColor = [UIColor greenColor];
+    uac.alertStyler.cancelButtonTitleColor = [UIColor redColor];
+    uac.alertStyler.cancelButtonTitleColor = [UIColor whiteColor];
     uac.alertStyler.backgroundColor = [UIColor orangeColor];
     uac.alertStyler.buttonTitleColor = [UIColor blackColor];
     uac.alertStyler.titleColor = [UIColor purpleColor];
@@ -92,7 +91,10 @@
     uac.alertStyler.alertViewShadowColor = [UIColor greenColor];
     uac.alertStyler.blurTintColor = [[UIColor blackColor] colorWithAlphaComponent:0.4];
     uac.alertStyler.messageAlignment = NSTextAlignmentRight;
-    [uac addAction:[URBNAlertAction actionWithTitle:@"Destructive" actionType:URBNAlertActionTypeDestructive actionCompleted:^(URBNAlertAction *action) {
+    uac.alertStyler.alertMinWidth = @150;
+    uac.alertStyler.alertMaxWidth = @200;
+
+    [uac addAction:[URBNAlertAction actionWithTitle:@"Cancel" actionType:URBNAlertActionTypeCancel actionCompleted:^(URBNAlertAction *action) {
         // Do something
     }]];
     

--- a/Pod/Classes/URBNAlertStyle.h
+++ b/Pod/Classes/URBNAlertStyle.h
@@ -107,6 +107,16 @@
 @property (nonatomic, strong) NSNumber *alertCornerRadius;
 
 /**
+ *  Minimum width the alert view can be. Note if using, alertMaxWidth must also be set
+ */
+@property (nonatomic, strong) NSNumber *alertMinWidth;
+
+/**
+ *  Maximum width the alert view can be. Note if using, alertMinWidth must also be set
+ */
+@property (nonatomic, strong) NSNumber *alertMaxWidth;
+
+/**
  * Max input length for the text field when enabled
  */
 @property (nonatomic, strong) NSNumber *textFieldMaxLength;

--- a/Pod/Classes/URBNAlertViewController.m
+++ b/Pod/Classes/URBNAlertViewController.m
@@ -152,21 +152,32 @@
     self.alertView.translatesAutoresizingMaskIntoConstraints = NO;
     
     CGFloat screenWidth;
-    
     if (self.alertConfig.presentationView) {
         screenWidth = self.alertConfig.presentationView.frame.size.width;
-    }
-    else if ([[UIScreen mainScreen] respondsToSelector:@selector(nativeBounds)]) {
-        screenWidth = [UIScreen mainScreen].nativeBounds.size.width;
     }
     else {
         screenWidth = [UIScreen mainScreen].bounds.size.width;
     }
     
     CGFloat sideMargins = screenWidth * 0.05;
-    
     NSDictionary *metrics = @{@"sideMargins" : @(sideMargins)};
-    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-sideMargins-[_alertView]-sideMargins-|" options:0 metrics:metrics views:NSDictionaryOfVariableBindings(_alertView)]];
+
+    if (self.alertStyler.alertMinWidth && self.alertStyler.alertMaxWidth) {
+        CGFloat minWidth = self.alertStyler.alertMinWidth.floatValue;
+        CGFloat maxWidthPossible = (screenWidth - (sideMargins * 2));
+        if (minWidth > maxWidthPossible) {
+            minWidth = maxWidthPossible;
+        }
+        
+        [self.view addConstraint:[NSLayoutConstraint constraintWithItem:self.alertView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationGreaterThanOrEqual toItem:nil attribute:NSLayoutAttributeWidth multiplier:1.0 constant:minWidth]];
+        
+        [self.view addConstraint:[NSLayoutConstraint constraintWithItem:self.alertView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationLessThanOrEqual toItem:nil attribute:NSLayoutAttributeWidth multiplier:1.0 constant:self.alertStyler.alertMaxWidth.floatValue]];
+        
+        [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|->=sideMargins-[_alertView]->=sideMargins-|" options:0 metrics:metrics views:NSDictionaryOfVariableBindings(_alertView)]];
+    }
+    else {
+        [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-sideMargins-[_alertView]-sideMargins-|" options:0 metrics:metrics views:NSDictionaryOfVariableBindings(_alertView)]];
+    }
     
     self.yPosConstraint = [NSLayoutConstraint constraintWithItem:self.alertView attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeCenterY multiplier:1.0 constant:0];
     [self.view addConstraint:self.yPosConstraint];


### PR DESCRIPTION
- If you set both, the alert will size based on those values, but while always keeping a 5% margin on each side
- If no max/min are set, it does the default behavior of stretching to the margin size
- Side margins are always 5% of the screen width in points
  Addresses issue #26
