### PR TITLE
Added vertical layout for buttons

### DIFF
--- a/Example/Tests/URBNAlertTests.m
+++ b/Example/Tests/URBNAlertTests.m
@@ -56,7 +56,7 @@
     uac = [[URBNAlertViewController alloc] initWithTitle:@"Title" message:@"Message"];
     [uac addAction:[URBNAlertAction actionWithTitle:@"btn1" actionType:URBNAlertActionTypeNormal actionCompleted:nil]];
     [uac addAction:[URBNAlertAction actionWithTitle:@"btn2" actionType:URBNAlertActionTypeNormal actionCompleted:nil]];
-    XCTAssertThrows([uac addAction:[URBNAlertAction actionWithTitle:@"btn3" actionType:URBNAlertActionTypeNormal actionCompleted:nil]]);
+    XCTAssertNoThrow([uac addAction:[URBNAlertAction actionWithTitle:@"btn3" actionType:URBNAlertActionTypeNormal actionCompleted:nil]]);
     
     //Test 2 buttons
     uac = [[URBNAlertViewController alloc] initWithTitle:@"Title" message:@"Message"];

--- a/Pod/Classes/URBNAlertStyle.h
+++ b/Pod/Classes/URBNAlertStyle.h
@@ -132,6 +132,21 @@
 @property (nonatomic, assign) UIEdgeInsets textFieldEdgeInsets;
 
 /**
+ *  Height of separator between buttons (as in native UIAlertController). Default is nil for compatibility
+ */
+@property (nonatomic, strong) NSNumber *separatorHeight;
+
+/**
+ * Color of the separator between buttons. Default is buttonTitleColor
+ */
+@property (nonatomic, strong) UIColor *separatorColor;
+
+/**
+ *  Boolean flag if to use vertical layout for 2 buttons (for 3+ always vertical being used). Default is nil for compatibility
+ */
+@property (nonatomic, strong) NSNumber *useVerticalLayoutForTwoButtons;
+
+/**
  * Height of the alert's buttons
  */
 @property (nonatomic, strong) NSNumber *buttonHeight;
@@ -140,6 +155,11 @@
  * Margin between sections in the alert. ie margin between the title and the message; message and the buttons, etc.
  */
 @property (nonatomic, strong) NSNumber *sectionVerticalMargin;
+
+/**
+ * Top margin
+ */
+@property (nonatomic, strong) NSNumber *topMargin;
 
 /**
  * Left & Right margins of the title & message labels

--- a/Pod/Classes/URBNAlertStyle.m
+++ b/Pod/Classes/URBNAlertStyle.m
@@ -17,6 +17,11 @@
 
 @implementation URBNAlertStyle
 
+#pragma mark - Margins
+- (NSNumber *)topMargin {
+    return _topMargin ?: [self sectionVerticalMargin];
+}
+
 #pragma mark - Title
 - (UIColor *)titleColor {
     return _titleColor ?: [UIColor blackColor];
@@ -52,7 +57,20 @@
     return _errorTextFont ?: [UIFont boldSystemFontOfSize:14];
 }
 
+#pragma mark - Separators
+- (NSNumber *)separatorHeight {
+    return _separatorHeight ?: @0;
+}
+
+- (UIColor *)separatorColor {
+    return _separatorColor ?: [self buttonTitleColor];
+}
+
 #pragma mark - Buttons
+- (NSNumber *)useVerticalLayoutForTwoButtons {
+    return _useVerticalLayoutForTwoButtons ?: @0;
+}
+
 - (UIColor *)buttonTitleColor {
     return _buttonTitleColor ?: [UIColor whiteColor];
 }
@@ -306,6 +324,10 @@
     styler.blurSaturationDelta = self.blurSaturationDelta;
     styler.errorTextColor = self.errorTextColor;
     styler.errorTextFont = self.errorTextFont;
+    styler.topMargin = self.topMargin;
+    styler.separatorColor = self.separatorColor;
+    styler.separatorHeight = self.separatorHeight;
+    styler.useVerticalLayoutForTwoButtons = self.useVerticalLayoutForTwoButtons;
     
     return styler;
 }

--- a/Pod/Classes/URBNAlertView.m
+++ b/Pod/Classes/URBNAlertView.m
@@ -82,11 +82,19 @@ static NSInteger const kURBNAlertViewHeightPadding = 80.f;
         
         // Add some buttons
         NSMutableArray *btns = [NSMutableArray new];
+        NSMutableArray *separators = [NSMutableArray new];
         buttonContainer.translatesAutoresizingMaskIntoConstraints = NO;
         
         __weak typeof(self) weakSelf = self;
         [self.alertConfig.actions enumerateObjectsUsingBlock:^(URBNAlertAction *action, NSUInteger idx, BOOL *stop) {
             if (action.isButton) {
+                if ([self.alertStyler.separatorHeight boolValue]) {
+                    UIView *sepatator = [UIView new];
+                    sepatator.backgroundColor = self.alertStyler.separatorColor;
+                    sepatator.translatesAutoresizingMaskIntoConstraints = NO;
+                    [buttonContainer addSubview:sepatator];
+                    [separators addObject:sepatator];
+                }
                 URBNAlertActionButton *btn = [weakSelf createAlertViewButtonWithAction:action atIndex:idx];
                 [buttonContainer addSubview:btn];
                 [btns addObject:btn];
@@ -111,12 +119,14 @@ static NSInteger const kURBNAlertViewHeightPadding = 80.f;
         NSDictionary *metrics = @{@"sectionMargin" : self.alertStyler.sectionVerticalMargin,
                                   @"btnH" : self.alertStyler.buttonHeight,
                                   @"lblHMargin" : self.alertStyler.labelHorizontalMargin,
-                                  @"titleVMargin" : titleMargin,
+                                  @"topVMargin" : @([titleMargin doubleValue] + [self.alertStyler.topMargin doubleValue]),
                                   @"msgVMargin" : msgMargin,
+                                  @"sprHeight"  : self.alertStyler.separatorHeight,
                                   @"btnTopMargin" : @(self.alertStyler.buttonMarginEdgeInsets.top),
                                   @"btnLeftMargin" : @(self.alertStyler.buttonMarginEdgeInsets.left),
                                   @"btnBottomMargin" : @(self.alertStyler.buttonMarginEdgeInsets.bottom),
                                   @"btnRightMargin" : @(self.alertStyler.buttonMarginEdgeInsets.right),
+                                  @"btnVInterval" : @(self.alertStyler.buttonMarginEdgeInsets.top + self.alertStyler.buttonMarginEdgeInsets.bottom),
                                   @"cvMargin" : self.alertStyler.customViewMargin,
                                   @"tfVMargin": self.alertStyler.textFieldVerticalMargin};
         
@@ -129,15 +139,15 @@ static NSInteger const kURBNAlertViewHeightPadding = 80.f;
         
         if (!self.alertConfig.inputs && self.alertConfig.inputs.count == 0) {
             if (self.alertConfig.isActiveAlert) {
-                [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-titleVMargin-[_titleLabel]-msgVMargin-[_messageTextView]-cvMargin-[_customView]-5-[_errorLabel]-cvMargin-[buttonContainer]|" options:0 metrics:metrics views:views]];
+                [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-topVMargin-[_titleLabel]-msgVMargin-[_messageTextView]-cvMargin-[_customView]-5-[_errorLabel]-cvMargin-[buttonContainer]|" options:0 metrics:metrics views:views]];
             }
             // Passive alert, dont added margins for buttonContainer
             else {
-                [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-titleVMargin-[_titleLabel]-msgVMargin-[_messageTextView]-cvMargin-[_customView]-cvMargin-|" options:0 metrics:metrics views:views]];
+                [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-topVMargin-[_titleLabel]-msgVMargin-[_messageTextView]-cvMargin-[_customView]-cvMargin-|" options:0 metrics:metrics views:views]];
             }
         }
         else {
-            NSMutableString *vertVfl = [NSMutableString stringWithString:@"V:|-titleVMargin-[_titleLabel]-msgVMargin-[_messageTextView]-cvMargin-[_customView]-cvMargin-"];
+            NSMutableString *vertVfl = [NSMutableString stringWithString:@"V:|-topVMargin-[_titleLabel]-msgVMargin-[_messageTextView]-cvMargin-[_customView]-cvMargin-"];
             
             [self.alertConfig.inputs enumerateObjectsUsingBlock:^(UITextField *tf, NSUInteger idx, BOOL *stop) {
                 [vertVfl appendString:[NSString stringWithFormat:@"[textField%lu]-tfVMargin-", (unsigned long)idx]];
@@ -151,19 +161,44 @@ static NSInteger const kURBNAlertViewHeightPadding = 80.f;
         
         // Button Constraints
         self.buttons = [btns copy];
+        self.sectionCount++;
         if (self.buttons.count == 1) {
-            self.sectionCount++;
             [buttonContainer addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-btnLeftMargin-[btnOne]-btnRightMargin-|" options:0 metrics:metrics views:@{@"btnOne" : self.buttons.firstObject}]];
             [buttonContainer addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-btnTopMargin-[btnOne(btnH)]-btnBottomMargin-|" options:0 metrics:metrics views:@{@"btnOne" : self.buttons.firstObject}]];
         }
-        else if (self.buttons.count == 2) {
-            self.sectionCount++;
+        else if (self.buttons.count == 2 && !self.alertStyler.useVerticalLayoutForTwoButtons.boolValue) {
             [buttonContainer addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-btnLeftMargin-[btnOne]-btnRightMargin-[btnTwo(==btnOne)]-btnRightMargin-|" options:0 metrics:metrics views:@{@"btnOne" : self.buttons.firstObject, @"btnTwo" : self.buttons[1]}]];
             [buttonContainer addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-btnTopMargin-[btnOne(btnH)]-btnBottomMargin-|" options:0 metrics:metrics views:@{@"btnOne" : self.buttons.firstObject}]];
             [buttonContainer addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-btnTopMargin-[btnTwo(btnH)]-btnBottomMargin-|" options:0 metrics:metrics views:@{@"btnTwo" : self.buttons[1]}]];
         }
-        // TODO: Handle 3+ buttons with a vertical layout
-        
+        else {
+            NSMutableDictionary *viewsDictionary = [NSMutableDictionary new];
+            NSMutableString *verticalConstraintsFormat = [NSMutableString stringWithString:@"V:|"];
+            for (int i = 0; i < self.buttons.count; i++) {
+                NSString *buttonName = [NSString stringWithFormat:@"btn%d", i];
+                [viewsDictionary setValue:self.buttons[i] forKey:buttonName];
+                if ([separators count]) {
+                    NSString *separatorName = [NSString stringWithFormat:@"spr%d", i];
+                    [verticalConstraintsFormat appendFormat:@"[%@(sprHeight)]-btnTopMargin-", separatorName];
+                    [viewsDictionary setValue:separators[i] forKey:separatorName];
+                    [buttonContainer addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-btnLeftMargin-[separator]-btnRightMargin-|" options:0 metrics:metrics views:@{@"separator" : separators[i]}]];
+                }
+                else if (i == 0) {
+                    [verticalConstraintsFormat appendString:@"-btnTopMargin-"];
+                }
+                else {
+                    [verticalConstraintsFormat appendString:@"-btnVInterval-"];
+                }
+                [verticalConstraintsFormat appendFormat:@"[%@(btnH)]", buttonName];
+                [buttonContainer addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-btnLeftMargin-[button]-btnRightMargin-|" options:0 metrics:metrics views:@{@"button" : self.buttons[i]}]];
+            }
+            if (self.buttons.count) {
+                [verticalConstraintsFormat appendString:@"-btnBottomMargin-|"];
+                [buttonContainer addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:verticalConstraintsFormat options:0 metrics:metrics views:viewsDictionary]];
+            }
+
+        }
+
         [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[buttonContainer]|" options:0 metrics:metrics views:views]];
         
         // If passive alert & a passive action was added, need call back when alertview is touched
@@ -181,6 +216,14 @@ static NSInteger const kURBNAlertViewHeightPadding = 80.f;
     [self.messageTextView layoutIfNeeded];
     
     CGFloat buttonHeight = self.buttons.count == 0 ? 0 : self.alertStyler.buttonHeight.floatValue;
+    CGFloat numberOfVerticalButtons;
+
+    if (self.buttons.count == 2 && !self.alertStyler.useVerticalLayoutForTwoButtons.boolValue) {
+        numberOfVerticalButtons = 1;
+    } else {
+        numberOfVerticalButtons = self.buttons.count;
+    }
+
     CGFloat screenHeight = SCREEN_HEIGHT;
     
     // Need this check because before iOS 8 screen.bounes.size is NOT orientation dependent
@@ -188,9 +231,9 @@ static NSInteger const kURBNAlertViewHeightPadding = 80.f;
     if ((SYSTEM_VERSION_LESS_THAN(@"8.0")) && UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)) {
         screenHeight = screenSize.width;
     }
-    
-    CGFloat maxHeight = screenHeight - self.titleLabel.intrinsicContentSize.height - (self.alertStyler.sectionVerticalMargin.floatValue * self.sectionCount) - buttonHeight - kURBNAlertViewHeightPadding;
-    
+
+        CGFloat maxHeight = screenHeight - self.titleLabel.intrinsicContentSize.height - (self.alertStyler.sectionVerticalMargin.floatValue * self.sectionCount) - buttonHeight * numberOfVerticalButtons - kURBNAlertViewHeightPadding;
+
     if (!self.messageTextView.urbn_heightLayoutConstraint) {
         [self.messageTextView urbn_addHeightLayoutConstraintWithConstant:0];
     }

--- a/Pod/Classes/URBNAlertViewController.m
+++ b/Pod/Classes/URBNAlertViewController.m
@@ -115,8 +115,6 @@
     NSMutableArray *actions = [self.alertConfig.actions mutableCopy] ?: [NSMutableArray new];
     [actions addObject:action];
     
-//    NSAssert(actions.count <= 2, @"URBNAlertController: Active alerts only supports up to 2 buttons at the moment. Please create an issue if you want more!");
-    
     self.alertConfig.actions = [actions copy];
     
     if (action.actionType != URBNAlertActionTypePassive) {

--- a/Pod/Classes/URBNAlertViewController.m
+++ b/Pod/Classes/URBNAlertViewController.m
@@ -115,7 +115,7 @@
     NSMutableArray *actions = [self.alertConfig.actions mutableCopy] ?: [NSMutableArray new];
     [actions addObject:action];
     
-    NSAssert(actions.count <= 2, @"URBNAlertController: Active alerts only supports up to 2 buttons at the moment. Please create an issue if you want more!");
+//    NSAssert(actions.count <= 2, @"URBNAlertController: Active alerts only supports up to 2 buttons at the moment. Please create an issue if you want more!");
     
     self.alertConfig.actions = [actions copy];
     


### PR DESCRIPTION
I found out that it's impossible with present configuration to make an AlertView with vertical layout for buttons. For example if you want to make AlertView looking like native UIAlertController view, but with different fonts and colors.
So, I've added vertical layout for two buttons (with flag useVerticalLayoutForTwoButtons) and it's default for 3+ buttons.
Also I've added separators between buttons (with separatorColor and separatorHeight)
Also topMargin value added, what is being added on top of existing margins (because for now it's impossible with single sectionVerticalMargin parameter to mange top margin)
The compatibility is preserved. So, all existing usages without those new parameters will work absolutely the same way. 
