### PR TITLE
Fixed issue with URBNAlert in apps using a light preferredStatusBarStyle

### DIFF
--- a/Pod/Classes/URBNAlertViewController.m
+++ b/Pod/Classes/URBNAlertViewController.m
@@ -355,4 +355,8 @@
     }];
 }
 
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return self.alertController.presentingWindow.rootViewController.preferredStatusBarStyle;
+}
+
 @end

--- a/URBNAlert.podspec
+++ b/URBNAlert.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "URBNAlert"
-  s.version          = "1.9"
+  s.version          = "1.9.1"
   s.summary          = "A custom alert view based off of UIAlertController but highly customizable."
   s.homepage         = "https://github.com/urbn/URBNAlert"
   s.license          = 'MIT'


### PR DESCRIPTION
If your apps VC are returning `UIStatusBarStyleLightContent` for `preferredStatusBarStyle`, you would see some flickering of the status bar when the URBNAlert was shown and dismissed.

URBNAlertViewController returned the default `preferredStatusBarStyle`, which is black. The fix is a coupe of lines, but fixes the ugliness that was going on.
