### PR TITLE
don't cage convenience and bump spec

### DIFF
--- a/URBNAlert.podspec
+++ b/URBNAlert.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "URBNAlert"
-  s.version          = "1.9.1"
+  s.version          = "1.9.2"
   s.summary          = "A custom alert view based off of UIAlertController but highly customizable."
   s.homepage         = "https://github.com/urbn/URBNAlert"
   s.license          = 'MIT'
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
 
   s.platform     = :ios, '7.0'
   s.requires_arc = true
-  s.dependency 'URBNConvenience', '~> 0.8.2'
+  s.dependency 'URBNConvenience', '> 0.8.2'
 
   s.source_files = 'Pod/Classes/**/*'
   s.resource_bundles = {


### PR DESCRIPTION
squiggly rule was keeping us down

there's no reason not to allow the new versions of convenience 

[reference](https://guides.cocoapods.org/using/the-podfile.html)
