### PR TITLE
fix issue where URBNSwiftyConvenience 1.6 can’t be used

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - URBNAlert (3.0):
-    - URBNSwiftyConvenience (~> 1.5.0)
-  - URBNSwiftyConvenience (1.5.0)
+  - URBNAlert (3.0.1):
+    - URBNSwiftyConvenience (~> 1.5)
+  - URBNSwiftyConvenience (1.6.0)
 
 DEPENDENCIES:
   - URBNAlert (from `../`)
@@ -15,8 +15,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  URBNAlert: 6663c4a1f9862c608c7368ddda4b93eb3543118d
-  URBNSwiftyConvenience: 6f35fa8fa3bd52d2efeedc67ff056320eac171e8
+  URBNAlert: fe4e56f661ed2c4f57a55880f075f3cce36350cf
+  URBNSwiftyConvenience: e583864a1a78703c5c4733e41ec54c76ec287e87
 
 PODFILE CHECKSUM: 87e3881e2b100a66f2819cf0b176b293a7deaf61
 

--- a/URBNAlert.podspec
+++ b/URBNAlert.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 s.name             = 'URBNAlert'
-s.version          = '3.0'
+s.version          = '3.0.1'
 s.summary          = 'A swift version of URBNAlert by Ryan Garchinsky.'
 
 
@@ -11,5 +11,5 @@ s.source           = { :git => 'https://github.com/urbn/URBNAlert.git', :tag => 
 s.platform         = :ios, '10.0'
 s.requires_arc     = true
 s.source_files     = 'URBNAlert/Classes/**/*'
-s.dependency 'URBNSwiftyConvenience', '~> 1.5.0'
+s.dependency 'URBNSwiftyConvenience', '~> 1.5'
 end


### PR DESCRIPTION
fix issue where URBNSwiftyConvenience 1.6 can’t be used

https://depfu.com/blog/2016/12/14/get-to-know-your-twiddle-wakka

😒 ruby developers